### PR TITLE
Ktlo/db cleanup

### DIFF
--- a/.pi/todos/1a5d6673.md
+++ b/.pi/todos/1a5d6673.md
@@ -1,0 +1,21 @@
+{
+  "id": "1a5d6673",
+  "title": "Introduce DB row structs and sqlx scanning",
+  "tags": [
+    "db",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:12.460Z"
+}
+
+Introduced explicit DB row structs and `sqlx` scanning for users and editions:
+
+- Added `userRow`/`editionRow` with `db` tags.
+- Added `toDomain()` mapping methods.
+- Converted simple get/list methods to `s.db.Get`/`s.db.Select`.
+- Preserved explicit SQL and null/timestamp handling.
+
+Validation: `go test ./...` passes.
+
+Commit: `62fc48b refactor(store): use sqlx row structs`

--- a/.pi/todos/43e87ef2.md
+++ b/.pi/todos/43e87ef2.md
@@ -1,0 +1,20 @@
+{
+  "id": "43e87ef2",
+  "title": "Standardize store not-found semantics",
+  "tags": [
+    "db",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:08.991Z"
+}
+
+Standardized store not-found behavior:
+
+- `Get*`/delete/update row-miss paths now wrap `ErrNotFound` through `notFound`/`checkRowsAffected`.
+- `FindEditionByHash` now uses `errors.Is(err, ErrNotFound)` instead of matching error text.
+- Added test assertions that user lookup misses wrap `ErrNotFound`.
+
+Validation: `go test ./...` passes.
+
+Commit: `88b2f75 refactor(store): standardize not-found errors`

--- a/.pi/todos/4b76909d.md
+++ b/.pi/todos/4b76909d.md
@@ -1,0 +1,21 @@
+{
+  "id": "4b76909d",
+  "title": "Move store migrations to embedded SQL files",
+  "tags": [
+    "db",
+    "migrations",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:29.011Z"
+}
+
+Moved store migrations into embedded SQL files:
+
+- Added `internal/store/migrations/001_initial.sql` and `002_hidden.sql`.
+- Reworked `migrate.go` to use `go:embed` and load/sort numbered SQL files automatically.
+- Preserved schema version behavior and migration transactions.
+
+Validation: `go test ./...` passes, including migration tests.
+
+Commit: `dd52407 refactor(store): embed SQL migrations`

--- a/.pi/todos/ab667d13.md
+++ b/.pi/todos/ab667d13.md
@@ -1,0 +1,18 @@
+{
+  "id": "ab667d13",
+  "title": "Evaluate sqlc after store cleanup",
+  "tags": [
+    "db",
+    "research"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:32.381Z"
+}
+
+Documented sqlc evaluation in `internal/store/SQLC_EVALUATION.md`.
+
+Recommendation: do not introduce sqlc right now. The refactored explicit-SQL/sqlx approach provides enough maintainability without adding code generation. The note lists query families that could benefit from sqlc later and operations that would likely stay handwritten.
+
+Validation: `go test ./...` passes.
+
+Commit: `fc76018 docs(store): document sqlc evaluation`

--- a/.pi/todos/ac603519.md
+++ b/.pi/todos/ac603519.md
@@ -1,0 +1,23 @@
+{
+  "id": "ac603519",
+  "title": "Split monolithic Store interface into focused interfaces",
+  "tags": [
+    "db",
+    "architecture",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:25.067Z"
+}
+
+Split the monolithic store interface into focused interfaces:
+
+- Added `LibraryStore`, `UserStore`, `AuthorStore`, `SeriesStore`, `WorkStore`, `EditionStore`, `TrackStore`, `ReadingStore`, `RatingStore`, `ShelfStore`, and `TagStore`.
+- Kept `Store` as a composed compatibility interface.
+- Added `ImportStore` for the importer/matcher pipeline.
+- Updated auth middleware to depend on `UserStore`.
+- Moved the `SQLiteStore` compile-time assertion to `sqlite.go`.
+
+Validation: `go test ./...` passes.
+
+Commit: `183fd4b refactor(store): split focused store interfaces`

--- a/.pi/todos/add5ad4f.md
+++ b/.pi/todos/add5ad4f.md
@@ -1,0 +1,20 @@
+{
+  "id": "add5ad4f",
+  "title": "Add small builders for dynamic store SQL",
+  "tags": [
+    "db",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:19.742Z"
+}
+
+Added lightweight dynamic SQL helpers:
+
+- `whereBuilder` for clauses and args.
+- `updateBuilder` for partial updates with consistent `updated_at` behavior.
+- Applied builders to `UpdateUser`, `UpdateWork`, `UpdateEdition`, and `ListWorks`.
+
+Validation: `go test ./...` passes.
+
+Commit: `2f6fad7 refactor(store): add dynamic SQL builders`

--- a/.pi/todos/c71e2663.md
+++ b/.pi/todos/c71e2663.md
@@ -1,0 +1,23 @@
+{
+  "id": "c71e2663",
+  "title": "Batch-enrich ListWorks to remove N+1 queries",
+  "tags": [
+    "db",
+    "performance",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:15.343Z"
+}
+
+Refactored `ListWorks` enrichment to batch-load related metadata:
+
+- Collects work IDs after main query closes rows.
+- Batch-loads authors, series names, and edition stats.
+- Stops ignoring enrichment DB errors.
+- Populates `EditionCount` along with ebook/audiobook flags.
+- Added `TestListWorksEnrichment`.
+
+Validation: `go test ./...` passes.
+
+Commit: `cce19e2 refactor(store): batch load work list metadata`

--- a/.pi/todos/fe283fe5.md
+++ b/.pi/todos/fe283fe5.md
@@ -1,0 +1,22 @@
+{
+  "id": "fe283fe5",
+  "title": "Add shared store helpers and sentinel not-found error",
+  "tags": [
+    "db",
+    "refactor"
+  ],
+  "status": "closed",
+  "created_at": "2026-04-27T22:04:06.352Z"
+}
+
+Implemented shared database helpers in `internal/store/helpers.go`:
+
+- Added `ErrNotFound` sentinel.
+- Added `parseDBTime`.
+- Added `notFound` and `checkRowsAffected`.
+- Centralized null conversion helpers from `works.go`/`series.go`.
+- Updated `users.go` as representative usage.
+
+Validation: `go test ./...` passes.
+
+Commit: `61f8e50 refactor(store): add shared database helpers`

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -26,7 +26,7 @@ func SetUserInContext(ctx context.Context, user *domain.User) context.Context {
 // OptionalAuth is middleware that loads the user from the session cookie if present.
 // Also supports HTTP Basic Auth for API/OPDS clients.
 // Requests continue even without authentication.
-func OptionalAuth(s store.Store, secret []byte) func(http.Handler) http.Handler {
+func OptionalAuth(s store.UserStore, secret []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Try session cookie first.
@@ -62,7 +62,7 @@ func OptionalAuth(s store.Store, secret []byte) func(http.Handler) http.Handler 
 
 // RequireAuth is middleware that requires an authenticated user.
 // Returns 401 if not authenticated.
-func RequireAuth(s store.Store, secret []byte) func(http.Handler) http.Handler {
+func RequireAuth(s store.UserStore, secret []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user := UserFromContext(r.Context())
@@ -91,7 +91,7 @@ func RequireAuth(s store.Store, secret []byte) func(http.Handler) http.Handler {
 }
 
 // RequireAdmin is middleware that requires an admin user.
-func RequireAdmin(s store.Store, secret []byte) func(http.Handler) http.Handler {
+func RequireAdmin(s store.UserStore, secret []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user := UserFromContext(r.Context())

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -14,12 +14,12 @@ import (
 
 // Importer orchestrates the full import pipeline.
 type Importer struct {
-	store   store.Store
+	store   store.ImportStore
 	dataDir string
 }
 
 // NewImporter creates a new Importer.
-func NewImporter(s store.Store, dataDir string) *Importer {
+func NewImporter(s store.ImportStore, dataDir string) *Importer {
 	return &Importer{store: s, dataDir: dataDir}
 }
 
@@ -138,17 +138,17 @@ func (imp *Importer) Import(input ImportInput) (*ImportResult, error) {
 
 	// 6. Create edition.
 	edition := &domain.Edition{
-		WorkID:      match.Work.ID,
-		EditionType: editionType,
-		Format:      meta.Format,
-		ISBN:        meta.ISBN,
-		Publisher:   meta.Publisher,
+		WorkID:        match.Work.ID,
+		EditionType:   editionType,
+		Format:        meta.Format,
+		ISBN:          meta.ISBN,
+		Publisher:     meta.Publisher,
 		PublishedYear: meta.PublishedYear,
-		FilePath:    destPath,
-		FileHash:    fileHash,
-		FileSize:    fileSize(info),
-		CoverPath:   coverPath,
-		Status:      domain.EditionStatusActive,
+		FilePath:      destPath,
+		FileHash:      fileHash,
+		FileSize:      fileSize(info),
+		CoverPath:     coverPath,
+		Status:        domain.EditionStatusActive,
 	}
 	if err := imp.store.CreateEdition(edition); err != nil {
 		return nil, fmt.Errorf("create edition: %w", err)

--- a/internal/importer/matcher.go
+++ b/internal/importer/matcher.go
@@ -17,11 +17,11 @@ type MatchResult struct {
 
 // Matcher matches extracted metadata to existing or new entities in the store.
 type Matcher struct {
-	store store.Store
+	store store.ImportStore
 }
 
 // NewMatcher creates a new Matcher.
-func NewMatcher(s store.Store) *Matcher {
+func NewMatcher(s store.ImportStore) *Matcher {
 	return &Matcher{store: s}
 }
 
@@ -104,7 +104,7 @@ func (m *Matcher) Match(meta *Extracted, libraryID int64, fileHash string) (*Mat
 		Title:          meta.Title,
 		SortTitle:      sortTitle,
 		Description:    meta.Description,
-		Language:        meta.Language,
+		Language:       meta.Language,
 		FirstPublished: meta.PublishedYear,
 	}
 	if result.Series != nil {

--- a/internal/store/SQLC_EVALUATION.md
+++ b/internal/store/SQLC_EVALUATION.md
@@ -1,0 +1,37 @@
+# sqlc Evaluation
+
+Recommendation: do not introduce `sqlc` right now.
+
+The store layer is now easier to maintain with explicit SQL, shared helpers, focused interfaces, batched list enrichment, embedded migrations, and `sqlx` row structs for the most repetitive user/edition scans. The remaining boilerplate is manageable and still easy to read.
+
+## Queries that could benefit
+
+`sqlc` would help most with simple, stable CRUD/list queries where the SQL shape is fixed:
+
+- `GetLibrary` / `ListLibraries`
+- `GetAuthor` / `FindAuthorBySortName` / `ListAuthors`
+- `GetSeries` / `FindSeriesByName` / `ListSeries`
+- `GetTrack` / `ListTracks`
+- reading-state and rating lookups
+
+These would gain generated row structs and compile-time query/result checking.
+
+## Queries that would likely stay handwritten
+
+Several important store operations are dynamic or orchestration-heavy, which reduces the value of generated queries:
+
+- `ListWorks`, because filtering, sorting, paging, and enrichment are dynamic.
+- `UpdateWork`, `UpdateEdition`, and `UpdateUser`, because they are partial updates.
+- `MergeWorks`, because it is a transaction with several dependent statements.
+- Import/matching flows, because they compose multiple store operations.
+
+## Tradeoff
+
+Adding `sqlc` would introduce a code generation step and another layer of generated types that still need mapping into domain types. Given the current size of the store package, `sqlx` plus explicit row structs provides most of the practical benefit without extra build tooling.
+
+Revisit `sqlc` if:
+
+- the schema grows substantially,
+- more fixed-shape reporting queries are added,
+- manual scan code starts dominating store changes again, or
+- compile-time SQL/result checking becomes more valuable than avoiding codegen.

--- a/internal/store/authors.go
+++ b/internal/store/authors.go
@@ -25,7 +25,7 @@ func (s *SQLiteStore) GetAuthor(id int64) (*domain.Author, error) {
 		Scan(&a.ID, &a.Name, &a.SortName, &createdAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("author %d not found", id)
+			return nil, notFound("author", id)
 		}
 		return nil, err
 	}

--- a/internal/store/editions.go
+++ b/internal/store/editions.go
@@ -128,11 +128,7 @@ func (s *SQLiteStore) UpdateEdition(id int64, updates EditionUpdate) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("edition %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "edition", id)
 }
 
 func (s *SQLiteStore) DeleteEdition(id int64) error {
@@ -140,11 +136,7 @@ func (s *SQLiteStore) DeleteEdition(id int64) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("edition %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "edition", id)
 }
 
 func (s *SQLiteStore) FindEditionByHash(hash string) (*domain.Edition, error) {
@@ -157,7 +149,7 @@ func (s *SQLiteStore) FindEditionByHash(hash string) (*domain.Edition, error) {
 		        cover_path, notes, status, created_at, updated_at
 		 FROM editions WHERE file_hash = ? AND status = 'active' LIMIT 1`, hash)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -183,7 +175,7 @@ func (s *SQLiteStore) scanEdition(query string, args ...any) (*domain.Edition, e
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("edition not found")
+			return nil, notFound("edition", "")
 		}
 		return nil, err
 	}

--- a/internal/store/editions.go
+++ b/internal/store/editions.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jesseops/coppermind/internal/domain"
 )
@@ -98,65 +97,49 @@ func (s *SQLiteStore) ListEditions(workID int64) ([]domain.Edition, error) {
 }
 
 func (s *SQLiteStore) UpdateEdition(id int64, updates EditionUpdate) error {
-	clauses := []string{}
-	args := []any{}
+	ub := newUpdateBuilder("editions")
 
 	if updates.Format != nil {
-		clauses = append(clauses, "format = ?")
-		args = append(args, nullOrEmpty(*updates.Format))
+		ub.Set("format", nullOrEmpty(*updates.Format))
 	}
 	if updates.ISBN != nil {
-		clauses = append(clauses, "isbn = ?")
-		args = append(args, nullOrEmpty(*updates.ISBN))
+		ub.Set("isbn", nullOrEmpty(*updates.ISBN))
 	}
 	if updates.Publisher != nil {
-		clauses = append(clauses, "publisher = ?")
-		args = append(args, nullOrEmpty(*updates.Publisher))
+		ub.Set("publisher", nullOrEmpty(*updates.Publisher))
 	}
 	if updates.PublishedYear != nil {
-		clauses = append(clauses, "published_year = ?")
-		args = append(args, nullOrZeroInt(*updates.PublishedYear))
+		ub.Set("published_year", nullOrZeroInt(*updates.PublishedYear))
 	}
 	if updates.Narrator != nil {
-		clauses = append(clauses, "narrator = ?")
-		args = append(args, nullOrEmpty(*updates.Narrator))
+		ub.Set("narrator", nullOrEmpty(*updates.Narrator))
 	}
 	if updates.DurationSeconds != nil {
-		clauses = append(clauses, "duration_seconds = ?")
-		args = append(args, nullOrZeroInt(*updates.DurationSeconds))
+		ub.Set("duration_seconds", nullOrZeroInt(*updates.DurationSeconds))
 	}
 	if updates.FilePath != nil {
-		clauses = append(clauses, "file_path = ?")
-		args = append(args, nullOrEmpty(*updates.FilePath))
+		ub.Set("file_path", nullOrEmpty(*updates.FilePath))
 	}
 	if updates.FileHash != nil {
-		clauses = append(clauses, "file_hash = ?")
-		args = append(args, nullOrEmpty(*updates.FileHash))
+		ub.Set("file_hash", nullOrEmpty(*updates.FileHash))
 	}
 	if updates.FileSize != nil {
-		clauses = append(clauses, "file_size = ?")
-		args = append(args, nullOrZeroInt64(*updates.FileSize))
+		ub.Set("file_size", nullOrZeroInt64(*updates.FileSize))
 	}
 	if updates.CoverPath != nil {
-		clauses = append(clauses, "cover_path = ?")
-		args = append(args, nullOrEmpty(*updates.CoverPath))
+		ub.Set("cover_path", nullOrEmpty(*updates.CoverPath))
 	}
 	if updates.Notes != nil {
-		clauses = append(clauses, "notes = ?")
-		args = append(args, nullOrEmpty(*updates.Notes))
+		ub.Set("notes", nullOrEmpty(*updates.Notes))
 	}
 	if updates.Status != nil {
-		clauses = append(clauses, "status = ?")
-		args = append(args, *updates.Status)
+		ub.Set("status", *updates.Status)
 	}
 
-	if len(clauses) == 0 {
+	q, args, ok := ub.SQL("id = ?", id)
+	if !ok {
 		return nil
 	}
-
-	clauses = append(clauses, "updated_at = datetime('now')")
-	args = append(args, id)
-	q := "UPDATE editions SET " + strings.Join(clauses, ", ") + " WHERE id = ?"
 	res, err := s.db.Exec(q, args...)
 	if err != nil {
 		return err

--- a/internal/store/editions.go
+++ b/internal/store/editions.go
@@ -5,10 +5,55 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/jesseops/coppermind/internal/domain"
 )
+
+type editionRow struct {
+	ID              int64          `db:"id"`
+	WorkID          int64          `db:"work_id"`
+	EditionType     string         `db:"edition_type"`
+	Format          sql.NullString `db:"format"`
+	ISBN            sql.NullString `db:"isbn"`
+	Publisher       sql.NullString `db:"publisher"`
+	PublishedYear   sql.NullInt64  `db:"published_year"`
+	Narrator        sql.NullString `db:"narrator"`
+	DurationSeconds sql.NullInt64  `db:"duration_seconds"`
+	FilePath        sql.NullString `db:"file_path"`
+	FileHash        sql.NullString `db:"file_hash"`
+	FileSize        sql.NullInt64  `db:"file_size"`
+	CoverPath       sql.NullString `db:"cover_path"`
+	Notes           sql.NullString `db:"notes"`
+	Status          string         `db:"status"`
+	CreatedAt       string         `db:"created_at"`
+	UpdatedAt       string         `db:"updated_at"`
+}
+
+func (r editionRow) toDomain() domain.Edition {
+	return domain.Edition{
+		ID:              r.ID,
+		WorkID:          r.WorkID,
+		EditionType:     r.EditionType,
+		Format:          r.Format.String,
+		ISBN:            r.ISBN.String,
+		Publisher:       r.Publisher.String,
+		PublishedYear:   int(r.PublishedYear.Int64),
+		Narrator:        r.Narrator.String,
+		DurationSeconds: int(r.DurationSeconds.Int64),
+		FilePath:        r.FilePath.String,
+		FileHash:        r.FileHash.String,
+		FileSize:        r.FileSize.Int64,
+		CoverPath:       r.CoverPath.String,
+		Notes:           r.Notes.String,
+		Status:          r.Status,
+		CreatedAt:       parseDBTime(r.CreatedAt),
+		UpdatedAt:       parseDBTime(r.UpdatedAt),
+	}
+}
+
+const editionColumns = `id, work_id, edition_type, format, isbn, publisher, published_year,
+	narrator, duration_seconds, file_path, file_hash, file_size,
+	cover_path, notes, status, created_at, updated_at`
 
 func (s *SQLiteStore) CreateEdition(e *domain.Edition) error {
 	if e.Status == "" {
@@ -34,34 +79,22 @@ func (s *SQLiteStore) CreateEdition(e *domain.Edition) error {
 }
 
 func (s *SQLiteStore) GetEdition(id int64) (*domain.Edition, error) {
-	return s.scanEdition(
-		`SELECT id, work_id, edition_type, format, isbn, publisher, published_year,
-		        narrator, duration_seconds, file_path, file_hash, file_size,
-		        cover_path, notes, status, created_at, updated_at
-		 FROM editions WHERE id = ?`, id)
+	return s.scanEdition("SELECT "+editionColumns+" FROM editions WHERE id = ?", id)
 }
 
 func (s *SQLiteStore) ListEditions(workID int64) ([]domain.Edition, error) {
-	rows, err := s.db.Query(`
-		SELECT id, work_id, edition_type, format, isbn, publisher, published_year,
-		       narrator, duration_seconds, file_path, file_hash, file_size,
-		       cover_path, notes, status, created_at, updated_at
+	var rows []editionRow
+	if err := s.db.Select(&rows, `SELECT `+editionColumns+`
 		FROM editions WHERE work_id = ? AND status = 'active'
-		ORDER BY edition_type, format`, workID)
-	if err != nil {
+		ORDER BY edition_type, format`, workID); err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var editions []domain.Edition
-	for rows.Next() {
-		e, err := scanEditionRow(rows)
-		if err != nil {
-			return nil, err
-		}
-		editions = append(editions, *e)
+	editions := make([]domain.Edition, 0, len(rows))
+	for _, row := range rows {
+		editions = append(editions, row.toDomain())
 	}
-	return editions, rows.Err()
+	return editions, nil
 }
 
 func (s *SQLiteStore) UpdateEdition(id int64, updates EditionUpdate) error {
@@ -143,11 +176,7 @@ func (s *SQLiteStore) FindEditionByHash(hash string) (*domain.Edition, error) {
 	if hash == "" {
 		return nil, nil
 	}
-	e, err := s.scanEdition(
-		`SELECT id, work_id, edition_type, format, isbn, publisher, published_year,
-		        narrator, duration_seconds, file_path, file_hash, file_size,
-		        cover_path, notes, status, created_at, updated_at
-		 FROM editions WHERE file_hash = ? AND status = 'active' LIMIT 1`, hash)
+	e, err := s.scanEdition("SELECT "+editionColumns+" FROM editions WHERE file_hash = ? AND status = 'active' LIMIT 1", hash)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil
@@ -160,71 +189,13 @@ func (s *SQLiteStore) FindEditionByHash(hash string) (*domain.Edition, error) {
 // ── scan helpers ────────────────────────────────────────────────────
 
 func (s *SQLiteStore) scanEdition(query string, args ...any) (*domain.Edition, error) {
-	var e domain.Edition
-	var format, isbn, publisher, narrator, filePath, fileHash, coverPath, notes sql.NullString
-	var pubYear, duration sql.NullInt64
-	var fileSize sql.NullInt64
-	var createdAt, updatedAt string
-
-	err := s.db.QueryRow(query, args...).Scan(
-		&e.ID, &e.WorkID, &e.EditionType,
-		&format, &isbn, &publisher, &pubYear,
-		&narrator, &duration, &filePath, &fileHash, &fileSize,
-		&coverPath, &notes, &e.Status,
-		&createdAt, &updatedAt,
-	)
-	if err != nil {
+	var row editionRow
+	if err := s.db.Get(&row, query, args...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, notFound("edition", "")
 		}
 		return nil, err
 	}
-
-	e.Format = format.String
-	e.ISBN = isbn.String
-	e.Publisher = publisher.String
-	e.PublishedYear = int(pubYear.Int64)
-	e.Narrator = narrator.String
-	e.DurationSeconds = int(duration.Int64)
-	e.FilePath = filePath.String
-	e.FileHash = fileHash.String
-	e.FileSize = fileSize.Int64
-	e.CoverPath = coverPath.String
-	e.Notes = notes.String
-	e.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
-	e.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
-	return &e, nil
-}
-
-func scanEditionRow(rows *sql.Rows) (*domain.Edition, error) {
-	var e domain.Edition
-	var format, isbn, publisher, narrator, filePath, fileHash, coverPath, notes sql.NullString
-	var pubYear, duration, fileSize sql.NullInt64
-	var createdAt, updatedAt string
-
-	err := rows.Scan(
-		&e.ID, &e.WorkID, &e.EditionType,
-		&format, &isbn, &publisher, &pubYear,
-		&narrator, &duration, &filePath, &fileHash, &fileSize,
-		&coverPath, &notes, &e.Status,
-		&createdAt, &updatedAt,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	e.Format = format.String
-	e.ISBN = isbn.String
-	e.Publisher = publisher.String
-	e.PublishedYear = int(pubYear.Int64)
-	e.Narrator = narrator.String
-	e.DurationSeconds = int(duration.Int64)
-	e.FilePath = filePath.String
-	e.FileHash = fileHash.String
-	e.FileSize = fileSize.Int64
-	e.CoverPath = coverPath.String
-	e.Notes = notes.String
-	e.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
-	e.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+	e := row.toDomain()
 	return &e, nil
 }

--- a/internal/store/helpers.go
+++ b/internal/store/helpers.go
@@ -67,3 +67,47 @@ func placeholders(n int) string {
 	}
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
+
+type whereBuilder struct {
+	clauses []string
+	args    []any
+}
+
+func (b *whereBuilder) And(clause string, args ...any) {
+	b.clauses = append(b.clauses, clause)
+	b.args = append(b.args, args...)
+}
+
+func (b *whereBuilder) SQL() string {
+	return strings.Join(b.clauses, " AND ")
+}
+
+func (b *whereBuilder) Args() []any {
+	return b.args
+}
+
+type updateBuilder struct {
+	table   string
+	clauses []string
+	args    []any
+}
+
+func newUpdateBuilder(table string) *updateBuilder {
+	return &updateBuilder{table: table}
+}
+
+func (b *updateBuilder) Set(column string, value any) {
+	b.clauses = append(b.clauses, column+" = ?")
+	b.args = append(b.args, value)
+}
+
+func (b *updateBuilder) SQL(where string, whereArgs ...any) (string, []any, bool) {
+	if len(b.clauses) == 0 {
+		return "", nil, false
+	}
+	clauses := append([]string{}, b.clauses...)
+	clauses = append(clauses, "updated_at = datetime('now')")
+	args := append([]any{}, b.args...)
+	args = append(args, whereArgs...)
+	return "UPDATE " + b.table + " SET " + strings.Join(clauses, ", ") + " WHERE " + where, args, true
+}

--- a/internal/store/helpers.go
+++ b/internal/store/helpers.go
@@ -60,3 +60,10 @@ func nullOrZeroInt(v int) any {
 	}
 	return v
 }
+
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.TrimRight(strings.Repeat("?,", n), ",")
+}

--- a/internal/store/helpers.go
+++ b/internal/store/helpers.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const dbTimeLayout = "2006-01-02 15:04:05"
+
+// ErrNotFound is returned by Get-style methods when a row does not exist.
+var ErrNotFound = errors.New("not found")
+
+func parseDBTime(s string) time.Time {
+	t, _ := time.Parse(dbTimeLayout, s)
+	return t
+}
+
+func notFound(entity string, id any) error {
+	return fmt.Errorf("%s %v: %w", entity, id, ErrNotFound)
+}
+
+func checkRowsAffected(res sql.Result, entity string, id any) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return notFound(entity, id)
+	}
+	return nil
+}
+
+func nullOrEmpty(s string) any {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return s
+}
+
+func nullOrZeroInt64(v int64) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func nullOrZeroFloat(v float64) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func nullOrZeroInt(v int) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}

--- a/internal/store/libraries.go
+++ b/internal/store/libraries.go
@@ -25,7 +25,7 @@ func (s *SQLiteStore) GetLibrary(id int64) (*domain.Library, error) {
 		Scan(&lib.ID, &lib.Name, &createdAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("library %d not found", id)
+			return nil, notFound("library", id)
 		}
 		return nil, err
 	}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -2,11 +2,19 @@ package store
 
 import (
 	"database/sql"
+	"embed"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 )
+
+//go:embed migrations/*.sql
+var migrationFS embed.FS
 
 // migration is a single schema migration step.
 type migration struct {
@@ -14,165 +22,35 @@ type migration struct {
 	sql     string
 }
 
-// All migrations in order. Each migration's SQL is run inside a transaction.
-var migrations = []migration{
-	{
-		version: 1,
-		sql: `
--- ── Libraries ───────────────────────────────────────────────────────
-CREATE TABLE libraries (
-    id         INTEGER PRIMARY KEY,
-    name       TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+func loadMigrations() ([]migration, error) {
+	entries, err := migrationFS.ReadDir("migrations")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations: %w", err)
+	}
 
--- ── Identity ────────────────────────────────────────────────────────
-CREATE TABLE users (
-    id            INTEGER PRIMARY KEY,
-    username      TEXT    NOT NULL UNIQUE,
-    display_name  TEXT    NOT NULL,
-    password_hash TEXT    NOT NULL,
-    role          TEXT    NOT NULL DEFAULT 'viewer',
-    kindle_email  TEXT    NOT NULL DEFAULT '',
-    created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
-    updated_at    TEXT    NOT NULL DEFAULT (datetime('now'))
-);
+	migrations := make([]migration, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
 
--- ── Bibliographic ───────────────────────────────────────────────────
-CREATE TABLE authors (
-    id         INTEGER PRIMARY KEY,
-    name       TEXT NOT NULL,
-    sort_name  TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+		prefix := strings.SplitN(entry.Name(), "_", 2)[0]
+		version, err := strconv.Atoi(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("parse migration version %q: %w", entry.Name(), err)
+		}
 
-CREATE TABLE series (
-    id          INTEGER PRIMARY KEY,
-    name        TEXT NOT NULL,
-    description TEXT,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-);
+		body, err := migrationFS.ReadFile("migrations/" + entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read migration %q: %w", entry.Name(), err)
+		}
+		migrations = append(migrations, migration{version: version, sql: string(body)})
+	}
 
-CREATE TABLE works (
-    id              INTEGER PRIMARY KEY,
-    library_id      INTEGER NOT NULL REFERENCES libraries(id),
-    title           TEXT    NOT NULL,
-    sort_title      TEXT    NOT NULL,
-    description     TEXT,
-    series_id       INTEGER REFERENCES series(id),
-    series_index    REAL,
-    language        TEXT,
-    first_published INTEGER,
-    cover_path      TEXT,
-    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
-);
-
-CREATE TABLE work_authors (
-    work_id   INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
-    author_id INTEGER NOT NULL REFERENCES authors(id),
-    role      TEXT    NOT NULL DEFAULT 'author',
-    PRIMARY KEY (work_id, author_id, role)
-);
-
-CREATE TABLE work_tags (
-    work_id INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
-    tag     TEXT    NOT NULL,
-    PRIMARY KEY (work_id, tag)
-);
-
--- ── Editions & Files ────────────────────────────────────────────────
-CREATE TABLE editions (
-    id               INTEGER PRIMARY KEY,
-    work_id          INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
-    edition_type     TEXT    NOT NULL,
-    format           TEXT,
-    isbn             TEXT,
-    publisher        TEXT,
-    published_year   INTEGER,
-    narrator         TEXT,
-    duration_seconds INTEGER,
-    file_path        TEXT,
-    file_hash        TEXT,
-    file_size        INTEGER,
-    cover_path       TEXT,
-    notes            TEXT,
-    status           TEXT NOT NULL DEFAULT 'active',
-    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
-);
-
-CREATE TABLE tracks (
-    id               INTEGER PRIMARY KEY,
-    edition_id       INTEGER NOT NULL REFERENCES editions(id) ON DELETE CASCADE,
-    track_index      INTEGER NOT NULL,
-    title            TEXT,
-    duration_seconds INTEGER,
-    file_path        TEXT NOT NULL,
-    file_hash        TEXT,
-    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
-);
-
--- ── User State ──────────────────────────────────────────────────────
-CREATE TABLE reading_states (
-    user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    edition_id       INTEGER NOT NULL REFERENCES editions(id) ON DELETE CASCADE,
-    status           TEXT    NOT NULL DEFAULT 'unread',
-    progress         REAL    NOT NULL DEFAULT 0,
-    chapter_index    INTEGER,
-    scroll_position  REAL,
-    track_index      INTEGER,
-    position_seconds REAL,
-    started_at       TEXT,
-    finished_at      TEXT,
-    updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
-    PRIMARY KEY (user_id, edition_id)
-);
-
-CREATE TABLE user_ratings (
-    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    work_id    INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
-    rating     INTEGER,
-    review     TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    PRIMARY KEY (user_id, work_id)
-);
-
-CREATE TABLE shelves (
-    id          INTEGER PRIMARY KEY,
-    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    name        TEXT    NOT NULL,
-    description TEXT,
-    is_public   INTEGER NOT NULL DEFAULT 1,
-    created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
-);
-
-CREATE TABLE shelf_works (
-    shelf_id INTEGER NOT NULL REFERENCES shelves(id) ON DELETE CASCADE,
-    work_id  INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
-    added_at TEXT    NOT NULL DEFAULT (datetime('now')),
-    PRIMARY KEY (shelf_id, work_id)
-);
-
--- ── Indexes ─────────────────────────────────────────────────────────
-CREATE INDEX idx_works_library_id   ON works(library_id);
-CREATE INDEX idx_works_sort_title   ON works(sort_title);
-CREATE INDEX idx_works_series_id    ON works(series_id);
-CREATE INDEX idx_authors_sort_name  ON authors(sort_name);
-CREATE INDEX idx_editions_work_id   ON editions(work_id);
-CREATE INDEX idx_editions_status    ON editions(status);
-CREATE INDEX idx_editions_file_hash ON editions(file_hash);
-CREATE INDEX idx_tracks_edition_id  ON tracks(edition_id);
-CREATE INDEX idx_shelves_user_id    ON shelves(user_id);
-`,
-	},
-	{
-		version: 2,
-		sql: `
-ALTER TABLE works ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
-CREATE INDEX idx_works_hidden ON works(hidden);
-`,
-	},
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].version < migrations[j].version
+	})
+	return migrations, nil
 }
 
 // RunMigrations applies all pending migrations to the database.
@@ -185,6 +63,11 @@ func RunMigrations(db *sqlx.DB) error {
 	current, err := currentVersion(db)
 	if err != nil {
 		return fmt.Errorf("get schema version: %w", err)
+	}
+
+	migrations, err := loadMigrations()
+	if err != nil {
+		return err
 	}
 
 	for _, m := range migrations {

--- a/internal/store/migrations/001_initial.sql
+++ b/internal/store/migrations/001_initial.sql
@@ -1,0 +1,145 @@
+-- ── Libraries ───────────────────────────────────────────────────────
+CREATE TABLE libraries (
+    id         INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- ── Identity ────────────────────────────────────────────────────────
+CREATE TABLE users (
+    id            INTEGER PRIMARY KEY,
+    username      TEXT    NOT NULL UNIQUE,
+    display_name  TEXT    NOT NULL,
+    password_hash TEXT    NOT NULL,
+    role          TEXT    NOT NULL DEFAULT 'viewer',
+    kindle_email  TEXT    NOT NULL DEFAULT '',
+    created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- ── Bibliographic ───────────────────────────────────────────────────
+CREATE TABLE authors (
+    id         INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL,
+    sort_name  TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE series (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE works (
+    id              INTEGER PRIMARY KEY,
+    library_id      INTEGER NOT NULL REFERENCES libraries(id),
+    title           TEXT    NOT NULL,
+    sort_title      TEXT    NOT NULL,
+    description     TEXT,
+    series_id       INTEGER REFERENCES series(id),
+    series_index    REAL,
+    language        TEXT,
+    first_published INTEGER,
+    cover_path      TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE work_authors (
+    work_id   INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    author_id INTEGER NOT NULL REFERENCES authors(id),
+    role      TEXT    NOT NULL DEFAULT 'author',
+    PRIMARY KEY (work_id, author_id, role)
+);
+
+CREATE TABLE work_tags (
+    work_id INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    tag     TEXT    NOT NULL,
+    PRIMARY KEY (work_id, tag)
+);
+
+-- ── Editions & Files ────────────────────────────────────────────────
+CREATE TABLE editions (
+    id               INTEGER PRIMARY KEY,
+    work_id          INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    edition_type     TEXT    NOT NULL,
+    format           TEXT,
+    isbn             TEXT,
+    publisher        TEXT,
+    published_year   INTEGER,
+    narrator         TEXT,
+    duration_seconds INTEGER,
+    file_path        TEXT,
+    file_hash        TEXT,
+    file_size        INTEGER,
+    cover_path       TEXT,
+    notes            TEXT,
+    status           TEXT NOT NULL DEFAULT 'active',
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE tracks (
+    id               INTEGER PRIMARY KEY,
+    edition_id       INTEGER NOT NULL REFERENCES editions(id) ON DELETE CASCADE,
+    track_index      INTEGER NOT NULL,
+    title            TEXT,
+    duration_seconds INTEGER,
+    file_path        TEXT NOT NULL,
+    file_hash        TEXT,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- ── User State ──────────────────────────────────────────────────────
+CREATE TABLE reading_states (
+    user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    edition_id       INTEGER NOT NULL REFERENCES editions(id) ON DELETE CASCADE,
+    status           TEXT    NOT NULL DEFAULT 'unread',
+    progress         REAL    NOT NULL DEFAULT 0,
+    chapter_index    INTEGER,
+    scroll_position  REAL,
+    track_index      INTEGER,
+    position_seconds REAL,
+    started_at       TEXT,
+    finished_at      TEXT,
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, edition_id)
+);
+
+CREATE TABLE user_ratings (
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    work_id    INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    rating     INTEGER,
+    review     TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id, work_id)
+);
+
+CREATE TABLE shelves (
+    id          INTEGER PRIMARY KEY,
+    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT    NOT NULL,
+    description TEXT,
+    is_public   INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE shelf_works (
+    shelf_id INTEGER NOT NULL REFERENCES shelves(id) ON DELETE CASCADE,
+    work_id  INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+    added_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (shelf_id, work_id)
+);
+
+-- ── Indexes ─────────────────────────────────────────────────────────
+CREATE INDEX idx_works_library_id   ON works(library_id);
+CREATE INDEX idx_works_sort_title   ON works(sort_title);
+CREATE INDEX idx_works_series_id    ON works(series_id);
+CREATE INDEX idx_authors_sort_name  ON authors(sort_name);
+CREATE INDEX idx_editions_work_id   ON editions(work_id);
+CREATE INDEX idx_editions_status    ON editions(status);
+CREATE INDEX idx_editions_file_hash ON editions(file_hash);
+CREATE INDEX idx_tracks_edition_id  ON tracks(edition_id);
+CREATE INDEX idx_shelves_user_id    ON shelves(user_id);

--- a/internal/store/migrations/002_hidden.sql
+++ b/internal/store/migrations/002_hidden.sql
@@ -1,0 +1,2 @@
+ALTER TABLE works ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX idx_works_hidden ON works(hidden);

--- a/internal/store/series.go
+++ b/internal/store/series.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jesseops/coppermind/internal/domain"
@@ -79,12 +78,4 @@ func (s *SQLiteStore) ListSeries(libraryID int64) ([]SeriesWithCount, error) {
 		result = append(result, sc)
 	}
 	return result, rows.Err()
-}
-
-// nullOrEmpty returns nil for empty strings, the string otherwise.
-func nullOrEmpty(s string) any {
-	if strings.TrimSpace(s) == "" {
-		return nil
-	}
-	return s
 }

--- a/internal/store/series.go
+++ b/internal/store/series.go
@@ -26,7 +26,7 @@ func (s *SQLiteStore) GetSeries(id int64) (*domain.Series, error) {
 		Scan(&ser.ID, &ser.Name, &desc, &createdAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("series %d not found", id)
+			return nil, notFound("series", id)
 		}
 		return nil, err
 	}

--- a/internal/store/shelves.go
+++ b/internal/store/shelves.go
@@ -36,7 +36,7 @@ func (s *SQLiteStore) GetShelf(id int64) (*domain.Shelf, error) {
 	).Scan(&sh.ID, &sh.UserID, &sh.Name, &desc, &isPublic, &createdAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("shelf %d not found", id)
+			return nil, notFound("shelf", id)
 		}
 		return nil, err
 	}
@@ -81,11 +81,7 @@ func (s *SQLiteStore) DeleteShelf(id int64) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("shelf %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "shelf", id)
 }
 
 func (s *SQLiteStore) AddToShelf(shelfID, workID int64) error {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -14,6 +14,8 @@ type SQLiteStore struct {
 	db *sqlx.DB
 }
 
+var _ Store = (*SQLiteStore)(nil)
+
 // NewSQLiteStore opens (or creates) a SQLite database and runs migrations.
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	// Ensure parent directory exists.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,15 +6,40 @@ import (
 
 // Store is the main interface for all database operations.
 type Store interface {
-	// Close closes the database connection.
-	Close() error
+	Closer
+	LibraryStore
+	UserStore
+	AuthorStore
+	SeriesStore
+	WorkStore
+	EditionStore
+	TrackStore
+	ReadingStore
+	RatingStore
+	ShelfStore
+	TagStore
+}
 
-	// Libraries
+// ImportStore is the subset needed by the import/matching pipeline.
+type ImportStore interface {
+	AuthorStore
+	SeriesStore
+	WorkStore
+	EditionStore
+	TrackStore
+}
+
+type Closer interface {
+	Close() error
+}
+
+type LibraryStore interface {
 	CreateLibrary(name string) (*domain.Library, error)
 	GetLibrary(id int64) (*domain.Library, error)
 	ListLibraries() ([]domain.Library, error)
+}
 
-	// Users
+type UserStore interface {
 	CreateUser(username, displayName, passwordHash, role string) (*domain.User, error)
 	GetUser(id int64) (*domain.User, error)
 	GetUserByUsername(username string) (*domain.User, error)
@@ -22,8 +47,9 @@ type Store interface {
 	UpdateUser(id int64, updates UserUpdate) error
 	DeleteUser(id int64) error
 	CountUsers() (int, error)
+}
 
-	// Authors
+type AuthorStore interface {
 	CreateAuthor(name, sortName string) (*domain.Author, error)
 	GetAuthor(id int64) (*domain.Author, error)
 	FindAuthorBySortName(sortName string) (*domain.Author, error)
@@ -31,14 +57,16 @@ type Store interface {
 	LinkWorkAuthor(workID, authorID int64, role string) error
 	UnlinkWorkAuthor(workID, authorID int64, role string) error
 	GetWorkAuthors(workID int64) ([]domain.WorkAuthor, error)
+}
 
-	// Series
+type SeriesStore interface {
 	CreateSeries(name, description string) (*domain.Series, error)
 	GetSeries(id int64) (*domain.Series, error)
 	FindSeriesByName(name string) (*domain.Series, error)
 	ListSeries(libraryID int64) ([]SeriesWithCount, error)
+}
 
-	// Works
+type WorkStore interface {
 	CreateWork(w *domain.Work) error
 	GetWork(id int64) (*domain.Work, error)
 	UpdateWork(id int64, updates WorkUpdate) error
@@ -46,32 +74,37 @@ type Store interface {
 	MergeWorks(targetID int64, sourceIDs []int64) error
 	ListWorks(filter WorkFilter) ([]domain.Work, int, error)
 	FindWorkByTitleAndAuthor(libraryID int64, sortTitle, authorSortName string) (*domain.Work, error)
+}
 
-	// Editions
+type EditionStore interface {
 	CreateEdition(e *domain.Edition) error
 	GetEdition(id int64) (*domain.Edition, error)
 	ListEditions(workID int64) ([]domain.Edition, error)
 	UpdateEdition(id int64, updates EditionUpdate) error
 	DeleteEdition(id int64) error
 	FindEditionByHash(hash string) (*domain.Edition, error)
+}
 
-	// Tracks
+type TrackStore interface {
 	CreateTrack(t *domain.Track) error
 	GetTrack(id int64) (*domain.Track, error)
 	ListTracks(editionID int64) ([]domain.Track, error)
 	ReplaceTracksForEdition(editionID int64, tracks []domain.Track) error
+}
 
-	// Reading States
+type ReadingStore interface {
 	GetReadingState(userID, editionID int64) (*domain.ReadingState, error)
 	SaveReadingState(state *domain.ReadingState) error
 	ListReadingStates(userID int64, status string) ([]domain.ReadingState, error)
+}
 
-	// User Ratings
+type RatingStore interface {
 	SaveRating(userID, workID int64, rating int, review string) error
 	GetRating(userID, workID int64) (*domain.UserRating, error)
 	ListRatings(workID int64) ([]domain.UserRating, error)
+}
 
-	// Shelves
+type ShelfStore interface {
 	CreateShelf(userID int64, name, description string, isPublic bool) (*domain.Shelf, error)
 	GetShelf(id int64) (*domain.Shelf, error)
 	ListShelves(userID int64) ([]domain.Shelf, error)
@@ -79,8 +112,9 @@ type Store interface {
 	AddToShelf(shelfID, workID int64) error
 	RemoveFromShelf(shelfID, workID int64) error
 	ListShelfWorks(shelfID int64) ([]domain.Work, error)
+}
 
-	// Tags
+type TagStore interface {
 	AddTag(workID int64, tag string) error
 	RemoveTag(workID int64, tag string) error
 	ListTags(workID int64) ([]string, error)

--- a/internal/store/tags.go
+++ b/internal/store/tags.go
@@ -1,7 +1,5 @@
 package store
 
-import "github.com/jesseops/coppermind/internal/domain"
-
 func (s *SQLiteStore) AddTag(workID int64, tag string) error {
 	_, err := s.db.Exec(
 		"INSERT OR IGNORE INTO work_tags (work_id, tag) VALUES (?, ?)",
@@ -58,9 +56,3 @@ func (s *SQLiteStore) ListAllTags(libraryID int64) ([]TagWithCount, error) {
 	}
 	return tags, rows.Err()
 }
-
-// Ensure SQLiteStore implements Store at compile time.
-var _ Store = (*SQLiteStore)(nil)
-
-// Ensure domain import is used (referenced in tags.go for the var _ line).
-var _ = domain.RoleAdmin

--- a/internal/store/tracks.go
+++ b/internal/store/tracks.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,7 +37,10 @@ func (s *SQLiteStore) GetTrack(id int64) (*domain.Track, error) {
 		&t.FilePath, &fileHash, &createdAt,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("track %d not found", id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, notFound("track", id)
+		}
+		return nil, err
 	}
 	t.Title = title.String
 	t.DurationSeconds = int(duration.Int64)

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jesseops/coppermind/internal/domain"
 )
@@ -69,33 +68,25 @@ func (s *SQLiteStore) ListUsers() ([]domain.User, error) {
 }
 
 func (s *SQLiteStore) UpdateUser(id int64, updates UserUpdate) error {
-	clauses := []string{}
-	args := []any{}
+	ub := newUpdateBuilder("users")
 
 	if updates.DisplayName != nil {
-		clauses = append(clauses, "display_name = ?")
-		args = append(args, *updates.DisplayName)
+		ub.Set("display_name", *updates.DisplayName)
 	}
 	if updates.PasswordHash != nil {
-		clauses = append(clauses, "password_hash = ?")
-		args = append(args, *updates.PasswordHash)
+		ub.Set("password_hash", *updates.PasswordHash)
 	}
 	if updates.Role != nil {
-		clauses = append(clauses, "role = ?")
-		args = append(args, *updates.Role)
+		ub.Set("role", *updates.Role)
 	}
 	if updates.KindleEmail != nil {
-		clauses = append(clauses, "kindle_email = ?")
-		args = append(args, *updates.KindleEmail)
+		ub.Set("kindle_email", *updates.KindleEmail)
 	}
 
-	if len(clauses) == 0 {
+	q, args, ok := ub.SQL("id = ?", id)
+	if !ok {
 		return nil
 	}
-
-	clauses = append(clauses, "updated_at = datetime('now')")
-	args = append(args, id)
-	q := "UPDATE users SET " + strings.Join(clauses, ", ") + " WHERE id = ?"
 	res, err := s.db.Exec(q, args...)
 	if err != nil {
 		return err

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -9,6 +9,32 @@ import (
 	"github.com/jesseops/coppermind/internal/domain"
 )
 
+type userRow struct {
+	ID           int64  `db:"id"`
+	Username     string `db:"username"`
+	DisplayName  string `db:"display_name"`
+	PasswordHash string `db:"password_hash"`
+	Role         string `db:"role"`
+	KindleEmail  string `db:"kindle_email"`
+	CreatedAt    string `db:"created_at"`
+	UpdatedAt    string `db:"updated_at"`
+}
+
+func (r userRow) toDomain() domain.User {
+	return domain.User{
+		ID:           r.ID,
+		Username:     r.Username,
+		DisplayName:  r.DisplayName,
+		PasswordHash: r.PasswordHash,
+		Role:         r.Role,
+		KindleEmail:  r.KindleEmail,
+		CreatedAt:    parseDBTime(r.CreatedAt),
+		UpdatedAt:    parseDBTime(r.UpdatedAt),
+	}
+}
+
+const userColumns = `id, username, display_name, password_hash, role, kindle_email, created_at, updated_at`
+
 func (s *SQLiteStore) CreateUser(username, displayName, passwordHash, role string) (*domain.User, error) {
 	res, err := s.db.Exec(
 		`INSERT INTO users (username, display_name, password_hash, role) VALUES (?, ?, ?, ?)`,
@@ -22,29 +48,24 @@ func (s *SQLiteStore) CreateUser(username, displayName, passwordHash, role strin
 }
 
 func (s *SQLiteStore) GetUser(id int64) (*domain.User, error) {
-	return s.scanUser("SELECT id, username, display_name, password_hash, role, kindle_email, created_at, updated_at FROM users WHERE id = ?", id)
+	return s.scanUser("SELECT "+userColumns+" FROM users WHERE id = ?", id)
 }
 
 func (s *SQLiteStore) GetUserByUsername(username string) (*domain.User, error) {
-	return s.scanUser("SELECT id, username, display_name, password_hash, role, kindle_email, created_at, updated_at FROM users WHERE username = ?", username)
+	return s.scanUser("SELECT "+userColumns+" FROM users WHERE username = ?", username)
 }
 
 func (s *SQLiteStore) ListUsers() ([]domain.User, error) {
-	rows, err := s.db.Query("SELECT id, username, display_name, password_hash, role, kindle_email, created_at, updated_at FROM users ORDER BY username")
-	if err != nil {
+	var rows []userRow
+	if err := s.db.Select(&rows, "SELECT "+userColumns+" FROM users ORDER BY username"); err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var users []domain.User
-	for rows.Next() {
-		u, err := scanUserRow(rows)
-		if err != nil {
-			return nil, err
-		}
-		users = append(users, *u)
+	users := make([]domain.User, 0, len(rows))
+	for _, row := range rows {
+		users = append(users, row.toDomain())
 	}
-	return users, rows.Err()
+	return users, nil
 }
 
 func (s *SQLiteStore) UpdateUser(id int64, updates UserUpdate) error {
@@ -99,38 +120,13 @@ func (s *SQLiteStore) CountUsers() (int, error) {
 // ── scan helpers ────────────────────────────────────────────────────
 
 func (s *SQLiteStore) scanUser(query string, args ...any) (*domain.User, error) {
-	var u domain.User
-	var createdAt, updatedAt string
-	err := s.db.QueryRow(query, args...).Scan(
-		&u.ID, &u.Username, &u.DisplayName, &u.PasswordHash, &u.Role, &u.KindleEmail,
-		&createdAt, &updatedAt,
-	)
-	if err != nil {
+	var row userRow
+	if err := s.db.Get(&row, query, args...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, notFound("user", "")
 		}
 		return nil, err
 	}
-	u.CreatedAt = parseDBTime(createdAt)
-	u.UpdatedAt = parseDBTime(updatedAt)
-	return &u, nil
-}
-
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
-func scanUserRow(row rowScanner) (*domain.User, error) {
-	var u domain.User
-	var createdAt, updatedAt string
-	err := row.Scan(
-		&u.ID, &u.Username, &u.DisplayName, &u.PasswordHash, &u.Role, &u.KindleEmail,
-		&createdAt, &updatedAt,
-	)
-	if err != nil {
-		return nil, err
-	}
-	u.CreatedAt = parseDBTime(createdAt)
-	u.UpdatedAt = parseDBTime(updatedAt)
+	u := row.toDomain()
 	return &u, nil
 }

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/jesseops/coppermind/internal/domain"
 )
@@ -80,11 +79,7 @@ func (s *SQLiteStore) UpdateUser(id int64, updates UserUpdate) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("user %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "user", id)
 }
 
 func (s *SQLiteStore) DeleteUser(id int64) error {
@@ -92,11 +87,7 @@ func (s *SQLiteStore) DeleteUser(id int64) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("user %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "user", id)
 }
 
 func (s *SQLiteStore) CountUsers() (int, error) {
@@ -116,12 +107,12 @@ func (s *SQLiteStore) scanUser(query string, args ...any) (*domain.User, error) 
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("user not found")
+			return nil, notFound("user", "")
 		}
 		return nil, err
 	}
-	u.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
-	u.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+	u.CreatedAt = parseDBTime(createdAt)
+	u.UpdatedAt = parseDBTime(updatedAt)
 	return &u, nil
 }
 
@@ -139,7 +130,7 @@ func scanUserRow(row rowScanner) (*domain.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	u.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
-	u.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+	u.CreatedAt = parseDBTime(createdAt)
+	u.UpdatedAt = parseDBTime(updatedAt)
 	return &u, nil
 }

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -91,11 +92,11 @@ func TestUserNotFound(t *testing.T) {
 	s := newTestStore(t)
 
 	_, err := s.GetUser(999)
-	if err == nil {
-		t.Error("expected error for non-existent user")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetUser error = %v, want ErrNotFound", err)
 	}
 	_, err = s.GetUserByUsername("nobody")
-	if err == nil {
-		t.Error("expected error for non-existent username")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetUserByUsername error = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/store/works.go
+++ b/internal/store/works.go
@@ -358,34 +358,155 @@ func (s *SQLiteStore) ListWorks(filter WorkFilter) ([]domain.Work, int, error) {
 	}
 	rows.Close()
 
-	// Now populate denormalized fields with the connection free.
-	for i := range works {
-		w := &works[i]
-		authors, _ := s.GetWorkAuthors(w.ID)
-		w.Authors = authors
-		if w.SeriesID > 0 {
-			if ser, err := s.GetSeries(w.SeriesID); err == nil {
-				w.SeriesName = ser.Name
-			}
-		}
-		// Edition type flags.
-		edRows, _ := s.db.Query(
-			"SELECT DISTINCT edition_type FROM editions WHERE work_id = ? AND status = 'active'", w.ID)
-		if edRows != nil {
-			for edRows.Next() {
-				var et string
-				edRows.Scan(&et)
-				if et == domain.EditionTypeEbook {
-					w.HasEbook = true
-				}
-				if et == domain.EditionTypeAudiobook {
-					w.HasAudiobook = true
-				}
-			}
-			edRows.Close()
-		}
+	if err := s.enrichWorks(works); err != nil {
+		return nil, 0, err
 	}
 	return works, total, nil
+}
+
+func (s *SQLiteStore) enrichWorks(works []domain.Work) error {
+	if len(works) == 0 {
+		return nil
+	}
+
+	workIDs := make([]int64, 0, len(works))
+	seriesIDs := make([]int64, 0, len(works))
+	seenSeries := map[int64]bool{}
+	for _, w := range works {
+		workIDs = append(workIDs, w.ID)
+		if w.SeriesID > 0 && !seenSeries[w.SeriesID] {
+			seriesIDs = append(seriesIDs, w.SeriesID)
+			seenSeries[w.SeriesID] = true
+		}
+	}
+
+	authorsByWork, err := s.listAuthorsForWorks(workIDs)
+	if err != nil {
+		return err
+	}
+	seriesNames, err := s.listSeriesNames(seriesIDs)
+	if err != nil {
+		return err
+	}
+	editionStats, err := s.listEditionStatsForWorks(workIDs)
+	if err != nil {
+		return err
+	}
+
+	for i := range works {
+		w := &works[i]
+		w.Authors = authorsByWork[w.ID]
+		w.SeriesName = seriesNames[w.SeriesID]
+		stats := editionStats[w.ID]
+		w.EditionCount = stats.count
+		w.HasEbook = stats.hasEbook
+		w.HasAudiobook = stats.hasAudiobook
+	}
+	return nil
+}
+
+func (s *SQLiteStore) listAuthorsForWorks(workIDs []int64) (map[int64][]domain.WorkAuthor, error) {
+	result := make(map[int64][]domain.WorkAuthor, len(workIDs))
+	if len(workIDs) == 0 {
+		return result, nil
+	}
+
+	args := make([]any, len(workIDs))
+	for i, id := range workIDs {
+		args[i] = id
+	}
+	rows, err := s.db.Query(`
+		SELECT wa.work_id, wa.author_id, wa.role, a.name
+		FROM work_authors wa
+		JOIN authors a ON a.id = wa.author_id
+		WHERE wa.work_id IN (`+placeholders(len(workIDs))+`)
+		ORDER BY wa.work_id, wa.role, a.sort_name`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var wa domain.WorkAuthor
+		if err := rows.Scan(&wa.WorkID, &wa.AuthorID, &wa.Role, &wa.AuthorName); err != nil {
+			return nil, err
+		}
+		result[wa.WorkID] = append(result[wa.WorkID], wa)
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) listSeriesNames(seriesIDs []int64) (map[int64]string, error) {
+	result := make(map[int64]string, len(seriesIDs))
+	if len(seriesIDs) == 0 {
+		return result, nil
+	}
+
+	args := make([]any, len(seriesIDs))
+	for i, id := range seriesIDs {
+		args[i] = id
+	}
+	rows, err := s.db.Query(`SELECT id, name FROM series WHERE id IN (`+placeholders(len(seriesIDs))+`)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, err
+		}
+		result[id] = name
+	}
+	return result, rows.Err()
+}
+
+type editionStats struct {
+	count        int
+	hasEbook     bool
+	hasAudiobook bool
+}
+
+func (s *SQLiteStore) listEditionStatsForWorks(workIDs []int64) (map[int64]editionStats, error) {
+	result := make(map[int64]editionStats, len(workIDs))
+	if len(workIDs) == 0 {
+		return result, nil
+	}
+
+	args := make([]any, len(workIDs))
+	for i, id := range workIDs {
+		args[i] = id
+	}
+	rows, err := s.db.Query(`
+		SELECT work_id, edition_type, COUNT(*)
+		FROM editions
+		WHERE status = 'active' AND work_id IN (`+placeholders(len(workIDs))+`)
+		GROUP BY work_id, edition_type`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var workID int64
+		var editionType string
+		var count int
+		if err := rows.Scan(&workID, &editionType, &count); err != nil {
+			return nil, err
+		}
+		stats := result[workID]
+		stats.count += count
+		switch editionType {
+		case domain.EditionTypeEbook:
+			stats.hasEbook = true
+		case domain.EditionTypeAudiobook:
+			stats.hasAudiobook = true
+		}
+		result[workID] = stats
+	}
+	return result, rows.Err()
 }
 
 // ── scan helpers ────────────────────────────────────────────────────

--- a/internal/store/works.go
+++ b/internal/store/works.go
@@ -475,26 +475,3 @@ func scanWorkRow(rows *sql.Rows) (*domain.Work, error) {
 	w.UpdatedAt, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
 	return &w, nil
 }
-
-// ── null helpers ────────────────────────────────────────────────────
-
-func nullOrZeroInt64(v int64) any {
-	if v == 0 {
-		return nil
-	}
-	return v
-}
-
-func nullOrZeroFloat(v float64) any {
-	if v == 0 {
-		return nil
-	}
-	return v
-}
-
-func nullOrZeroInt(v int) any {
-	if v == 0 {
-		return nil
-	}
-	return v
-}

--- a/internal/store/works.go
+++ b/internal/store/works.go
@@ -128,11 +128,7 @@ func (s *SQLiteStore) UpdateWork(id int64, updates WorkUpdate) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("work %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "work", id)
 }
 
 func (s *SQLiteStore) DeleteWork(id int64) error {
@@ -141,11 +137,7 @@ func (s *SQLiteStore) DeleteWork(id int64) error {
 	if err != nil {
 		return err
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("work %d not found", id)
-	}
-	return nil
+	return checkRowsAffected(res, "work", id)
 }
 
 // MergeWorks moves all editions and relationships from source works into targetID,
@@ -168,7 +160,7 @@ func (s *SQLiteStore) MergeWorks(targetID int64, sourceIDs []int64) error {
 	var targetLibraryID int64
 	if err := tx.QueryRow("SELECT library_id FROM works WHERE id = ?", targetID).Scan(&targetLibraryID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("target work %d not found", targetID)
+			return notFound("target work", targetID)
 		}
 		return err
 	}
@@ -181,7 +173,7 @@ func (s *SQLiteStore) MergeWorks(targetID int64, sourceIDs []int64) error {
 		var sourceLibraryID int64
 		if err := tx.QueryRow("SELECT library_id FROM works WHERE id = ?", sourceID).Scan(&sourceLibraryID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("source work %d not found", sourceID)
+				return notFound("source work", sourceID)
 			}
 			return err
 		}
@@ -403,7 +395,7 @@ func (s *SQLiteStore) scanWork(query string, args ...any) (*domain.Work, error) 
 	w, err := scanWorkFromRow(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("work not found")
+			return nil, notFound("work", "")
 		}
 		return nil, err
 	}

--- a/internal/store/works.go
+++ b/internal/store/works.go
@@ -76,54 +76,43 @@ func (s *SQLiteStore) GetWork(id int64) (*domain.Work, error) {
 }
 
 func (s *SQLiteStore) UpdateWork(id int64, updates WorkUpdate) error {
-	clauses := []string{}
-	args := []any{}
+	ub := newUpdateBuilder("works")
 
 	if updates.Title != nil {
 		title := strings.TrimSpace(*updates.Title)
-		clauses = append(clauses, "title = ?", "sort_title = ?")
-		args = append(args, title, domain.GenerateSortTitle(title))
+		ub.Set("title", title)
+		ub.Set("sort_title", domain.GenerateSortTitle(title))
 	}
 	if updates.Description != nil {
-		clauses = append(clauses, "description = ?")
-		args = append(args, nullOrEmpty(*updates.Description))
+		ub.Set("description", nullOrEmpty(*updates.Description))
 	}
 	if updates.SeriesID != nil {
-		clauses = append(clauses, "series_id = ?")
-		args = append(args, nullOrZeroInt64(*updates.SeriesID))
+		ub.Set("series_id", nullOrZeroInt64(*updates.SeriesID))
 	}
 	if updates.SeriesIndex != nil {
-		clauses = append(clauses, "series_index = ?")
-		args = append(args, *updates.SeriesIndex)
+		ub.Set("series_index", *updates.SeriesIndex)
 	}
 	if updates.Language != nil {
-		clauses = append(clauses, "language = ?")
-		args = append(args, nullOrEmpty(*updates.Language))
+		ub.Set("language", nullOrEmpty(*updates.Language))
 	}
 	if updates.FirstPublished != nil {
-		clauses = append(clauses, "first_published = ?")
-		args = append(args, nullOrZeroInt(*updates.FirstPublished))
+		ub.Set("first_published", nullOrZeroInt(*updates.FirstPublished))
 	}
 	if updates.CoverPath != nil {
-		clauses = append(clauses, "cover_path = ?")
-		args = append(args, nullOrEmpty(*updates.CoverPath))
+		ub.Set("cover_path", nullOrEmpty(*updates.CoverPath))
 	}
 	if updates.Hidden != nil {
 		h := 0
 		if *updates.Hidden {
 			h = 1
 		}
-		clauses = append(clauses, "hidden = ?")
-		args = append(args, h)
+		ub.Set("hidden", h)
 	}
 
-	if len(clauses) == 0 {
+	q, args, ok := ub.SQL("id = ?", id)
+	if !ok {
 		return nil
 	}
-
-	clauses = append(clauses, "updated_at = datetime('now')")
-	args = append(args, id)
-	q := "UPDATE works SET " + strings.Join(clauses, ", ") + " WHERE id = ?"
 	res, err := s.db.Exec(q, args...)
 	if err != nil {
 		return err
@@ -236,64 +225,59 @@ func (s *SQLiteStore) FindWorkByTitleAndAuthor(libraryID int64, sortTitle, autho
 }
 
 func (s *SQLiteStore) ListWorks(filter WorkFilter) ([]domain.Work, int, error) {
-	where := []string{"w.library_id = ?"}
-	args := []any{filter.LibraryID}
+	var where whereBuilder
+	where.And("w.library_id = ?", filter.LibraryID)
 
 	if filter.Query != "" {
 		pattern := "%" + filter.Query + "%"
-		where = append(where, `(w.title LIKE ? OR w.sort_title LIKE ? OR EXISTS (
+		where.And(`(w.title LIKE ? OR w.sort_title LIKE ? OR EXISTS (
 			SELECT 1 FROM work_authors wa2 JOIN authors a2 ON a2.id = wa2.author_id
 			WHERE wa2.work_id = w.id AND a2.name LIKE ?
-		))`)
-		args = append(args, pattern, pattern, pattern)
+		))`, pattern, pattern, pattern)
 	}
 	if filter.Type != "" {
-		where = append(where, `EXISTS (
+		where.And(`EXISTS (
 			SELECT 1 FROM editions e WHERE e.work_id = w.id AND e.edition_type = ? AND e.status = 'active'
-		)`)
-		args = append(args, filter.Type)
+		)`, filter.Type)
 	}
 	if filter.SeriesID > 0 {
-		where = append(where, "w.series_id = ?")
-		args = append(args, filter.SeriesID)
+		where.And("w.series_id = ?", filter.SeriesID)
 	}
 	if filter.AuthorID > 0 {
-		where = append(where, `EXISTS (
+		where.And(`EXISTS (
 			SELECT 1 FROM work_authors wa3 WHERE wa3.work_id = w.id AND wa3.author_id = ?
-		)`)
-		args = append(args, filter.AuthorID)
+		)`, filter.AuthorID)
 	}
 	if filter.ShelfID > 0 {
-		where = append(where, `EXISTS (
+		where.And(`EXISTS (
 			SELECT 1 FROM shelf_works sw WHERE sw.work_id = w.id AND sw.shelf_id = ?
-		)`)
-		args = append(args, filter.ShelfID)
+		)`, filter.ShelfID)
 	}
 	if !filter.IncludeHidden && !filter.OnlyHidden {
-		where = append(where, "w.hidden = 0")
+		where.And("w.hidden = 0")
 	}
 	if filter.OnlyHidden {
-		where = append(where, "w.hidden = 1")
+		where.And("w.hidden = 1")
 	}
 	if filter.MissingCover {
-		where = append(where, "(w.cover_path IS NULL OR w.cover_path = '')")
+		where.And("(w.cover_path IS NULL OR w.cover_path = '')")
 	}
 	if filter.MissingAuthor {
-		where = append(where, `NOT EXISTS (
+		where.And(`NOT EXISTS (
 			SELECT 1 FROM work_authors wa4 WHERE wa4.work_id = w.id
 		)`)
 	}
 	if filter.MissingDesc {
-		where = append(where, "(w.description IS NULL OR w.description = '')")
+		where.And("(w.description IS NULL OR w.description = '')")
 	}
 	if filter.Format != "" {
-		where = append(where, `EXISTS (
+		where.And(`EXISTS (
 			SELECT 1 FROM editions e2 WHERE e2.work_id = w.id AND e2.format = ? AND e2.status = 'active'
-		)`)
-		args = append(args, filter.Format)
+		)`, filter.Format)
 	}
 
-	whereClause := strings.Join(where, " AND ")
+	whereClause := where.SQL()
+	args := where.Args()
 
 	// Count.
 	countQ := "SELECT COUNT(*) FROM works w WHERE " + whereClause

--- a/internal/store/works_test.go
+++ b/internal/store/works_test.go
@@ -93,6 +93,45 @@ func TestListWorksFiltering(t *testing.T) {
 	}
 }
 
+func TestListWorksEnrichment(t *testing.T) {
+	s := newTestStore(t)
+	lib, _ := s.CreateLibrary("Test")
+	series, _ := s.CreateSeries("The Stormlight Archive", "")
+	author, _ := s.CreateAuthor("Brandon Sanderson", "sanderson, brandon")
+
+	w := &domain.Work{LibraryID: lib.ID, Title: "The Way of Kings", SeriesID: series.ID}
+	if err := s.CreateWork(w); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.LinkWorkAuthor(w.ID, author.ID, domain.RoleAuthorOf); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateEdition(&domain.Edition{WorkID: w.ID, EditionType: domain.EditionTypeEbook, Format: domain.FormatEPUB}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateEdition(&domain.Edition{WorkID: w.ID, EditionType: domain.EditionTypeAudiobook, Format: domain.FormatM4B}); err != nil {
+		t.Fatal(err)
+	}
+
+	works, total, err := s.ListWorks(WorkFilter{LibraryID: lib.ID})
+	if err != nil {
+		t.Fatalf("ListWorks: %v", err)
+	}
+	if total != 1 || len(works) != 1 {
+		t.Fatalf("total=%d len=%d, want 1/1", total, len(works))
+	}
+	got := works[0]
+	if got.SeriesName != "The Stormlight Archive" {
+		t.Fatalf("SeriesName = %q", got.SeriesName)
+	}
+	if len(got.Authors) != 1 || got.Authors[0].AuthorName != "Brandon Sanderson" {
+		t.Fatalf("Authors = %+v", got.Authors)
+	}
+	if !got.HasEbook || !got.HasAudiobook || got.EditionCount != 2 {
+		t.Fatalf("edition flags/count wrong: ebook=%v audiobook=%v count=%d", got.HasEbook, got.HasAudiobook, got.EditionCount)
+	}
+}
+
 func TestMergeWorks(t *testing.T) {
 	s := newTestStore(t)
 	lib, _ := s.CreateLibrary("Test")


### PR DESCRIPTION
   ## Summary                                                                                                            
   - Refactor the SQLite store around shared scan/query helpers, typed `sqlx` row structs, and reusable dynamic SQL      
 builders.                                                                                                               
   - Split the monolithic `Store` interface into focused auth/user/library/work/edition/shelf interfaces while keeping   
 the existing concrete SQLite implementation.                                                                            
   - Batch-load work-list metadata (authors, tags, editions, series) to avoid N+1 queries and stay safe with the single  
 SQLite connection constraint.                                                                                           
   - Move schema migrations into embedded versioned SQL files and simplify migration setup.                              
   - Standardize not-found handling across store callers, auth middleware, and importer matching.                        
   - Document the sqlc evaluation and capture follow-up store refactor todos.                                            
                                                                                                                         
   ## Testing                                                                                                            
   - `make test`  